### PR TITLE
Fix TempEnv and Require Post Fields

### DIFF
--- a/backend/env_temp
+++ b/backend/env_temp
@@ -2,7 +2,7 @@
 MONGO_URL=
 
 #port number of the server
-port=3001
+PORT=3001
 
 #jwt secret
 JWT_SECRET=


### PR DESCRIPTION
Modifying "port" to "PORT" in temp_env and added '*' for required post fields.